### PR TITLE
Update netcat dependency in tests

### DIFF
--- a/test/client/Dockerfile
+++ b/test/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends openssh-client netcat && \
+    apt-get -y install --no-install-recommends openssh-client netcat-openbsd && \
     rm -rf /var/lib/apt/lists/* && \
     adduser --system clientuser
 

--- a/test/destination/Dockerfile
+++ b/test/destination/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stable-slim
 
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends netcat && \
+    apt-get -y install --no-install-recommends netcat-openbsd && \
     rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /


### PR DESCRIPTION
In Debian Bullseye, the `netcat` package was a transitional package that depended on `netcat-openbsd`. In Debian Bookworm, it is now a virtual package and you must explicitly install one of the packages that 'provides' it, either `netcat-openbsd` or `netcat-traditional`.

Fixes #5.