### PR TITLE
Allow script to succeed if /run/sshd already exists

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     # Create 'tunnel' user
     adduser --system --home /home/tunnel tunnel && \
     # Create runtime dir for sshd
-    mkdir /run/sshd
+    mkdir -p /run/sshd
 
 COPY sshd_config /etc/ssh/sshd_config.d/00base.conf
 COPY entrypoint.sh sshd-prometheus-exporter.py /


### PR DESCRIPTION
This fixes the following build error (see https://github.com/nasa-gcn/ssh-tunnel/actions/runs/16879244821/job/47810808601):

    mkdir: cannot create directory '/run/sshd': File exists